### PR TITLE
Fix navigation logo when switching to mobile

### DIFF
--- a/cypress/e2e/navigation.cy.ts
+++ b/cypress/e2e/navigation.cy.ts
@@ -48,6 +48,22 @@ describe("Sidebar Navigation", () => {
       // check that text is not rendered
       cy.get("nav").contains("Issues").should("not.exist");
     });
+
+    it("shows large logo when switching to landscape mode while navigation is collapsed", () => {
+      //collapse navigation
+      cy.get("nav").contains("Collapse").click();
+
+      //check that small logo is rendered
+      cy.get('img[src="/icons/logo-small.svg"').should("be.visible");
+      cy.get('img[src="/icons/logo-large.svg"').should("not.be.visible");
+
+      //switch to landscape mode that uses the mobile menu
+      cy.viewport(900, 1025);
+
+      //check that the large logo is shown
+      cy.get('img[src="/icons/logo-small.svg"').should("not.be.visible");
+      cy.get('img[src="/icons/logo-large.svg"').should("be.visible");
+    });
   });
 
   context("mobile resolution", () => {

--- a/features/layout/sidebar-navigation/sidebar-navigation.module.scss
+++ b/features/layout/sidebar-navigation/sidebar-navigation.module.scss
@@ -18,10 +18,6 @@
   &.isCollapsed {
     @media (min-width: breakpoint.$desktop) {
       width: 5.1875rem;
-
-      .logo {
-        width: 1.4375rem;
-      }
     }
   }
 }
@@ -53,6 +49,35 @@
 
   @media (min-width: breakpoint.$desktop) {
     margin: space.$s0 space.$s4;
+  }
+}
+
+.logoLarge {
+  // through css modules composes allows the large and small logo classes to inherit the shared logo class
+  // we add the logo class to remove code reptition
+  composes: logo;
+  width: 7.375rem;
+
+  @media (min-width: breakpoint.$desktop) {
+    margin: space.$s0 space.$s4;
+
+    &.isCollapsed {
+      display: none;
+    }
+  }
+}
+
+.logoSmall {
+  composes: logo;
+  display: none;
+  width: 1.4375rem;
+
+  @media (min-width: breakpoint.$desktop) {
+    margin: space.$s0 space.$s4;
+
+    &.isCollapsed {
+      display: block;
+    }
   }
 }
 

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -40,13 +40,20 @@ export function SidebarNavigation() {
         <header className={styles.header}>
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
-            src={
-              isSidebarCollapsed && window.innerWidth > 1024
-                ? "/icons/logo-small.svg"
-                : "/icons/logo-large.svg"
-            }
+            src={"/icons/logo-large.svg"}
             alt="logo"
-            className={styles.logo}
+            className={classNames(
+              styles.logoLarge,
+              isSidebarCollapsed && styles.isCollapsed,
+            )}
+          />
+          <img
+            src={"/icons/logo-small.svg"}
+            alt="logo"
+            className={classNames(
+              styles.logoSmall,
+              isSidebarCollapsed && styles.isCollapsed,
+            )}
           />
           <Button
             onClick={() => setMobileMenuOpen(!isMobileMenuOpen)}

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -41,7 +41,7 @@ export function SidebarNavigation() {
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
             src={
-              isSidebarCollapsed
+              isSidebarCollapsed && window.innerWidth > 1024
                 ? "/icons/logo-small.svg"
                 : "/icons/logo-large.svg"
             }


### PR DESCRIPTION
the small logo was overflowing the header when the navigation menu was collapsed and under certain screen sizes.